### PR TITLE
Allow to parse arrays

### DIFF
--- a/lib/puppet-lint/plugins/check_version_comparison.rb
+++ b/lib/puppet-lint/plugins/check_version_comparison.rb
@@ -10,7 +10,7 @@ PuppetLint.new_check(:version_comparison) do
   def check
     tokens.each_with_index do |token, token_idx|
       next unless token.type == :VARIABLE
-      next unless token.value =~ /(?:version|release)$/
+      next unless token.value =~ /(?:version|release)$|\[(?:version|release)\]|\['(?:version|release)'\]/
       next unless is_num_comparison?(token.next_code_token)
       notify :warning, {
         :message => 'version compared as number',
@@ -19,7 +19,7 @@ PuppetLint.new_check(:version_comparison) do
         :token   => token,
       }
     end
-  end 
+  end
 
   def compared_value(token)
     token.next_code_token.next_code_token.value


### PR DESCRIPTION
Allow to check for versions in arrays (eg. $::os['release']['major']). Using this complex regex to not allow things like $versioncontrol in which there wouldn't be a version.